### PR TITLE
Added extended challenge response support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Initialize the Yubikey for challenge response in slot 2
 Install package
 ---------------
 
+It may be necessary to install dependencies before building debians:
+
+    sudo apt-get install devscripts debhelper dh-exec
+    mk-build-deps
+
 Build the package (without signing it):
 
     make builddeb NO_SIGN=1

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Install package
 
 It may be necessary to install dependencies before building debians:
 
-    sudo apt-get install devscripts debhelper dh-exec
+    sudo apt install devscripts debhelper dh-exec
+    sudo apt install equivs
     mk-build-deps
 
 Build the package (without signing it):

--- a/key-script
+++ b/key-script
@@ -40,7 +40,12 @@ if [ "$check_yubikey_present" = "1" ]; then
     if [ "$HASH" = "1" ]; then
         PW=$(printf %s "$PW" | sha256sum | awk '{print $1}')
     fi
-    R="$(printf %s "$PW" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+    if [ -z "$EXTENDED_CHALLENGE" ]; then
+        R="$(printf %s "$PW" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+    else
+        yubikey_challenge=$(printf %s "yubikey-$PW" | sha256sum | awk '{print $1}')
+        R="$(printf %s "$yubikey_challenge" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+    fi
     if [ "$R" ]; then
         message "Retrieved the response from the Yubikey"
         if [ "$CONCATENATE" = "1" ]; then
@@ -52,7 +57,8 @@ if [ "$check_yubikey_present" = "1" ]; then
         message "Failed to retrieve the response from the Yubikey"
     fi
 else
-        printf '%s' "$PW"
+    message "No Yubikey detected. Resorting to recovery code entry ..."
+    printf '%s' "$PW"
 fi
 
 exit 0

--- a/key-script
+++ b/key-script
@@ -4,7 +4,15 @@
 #
 YUBIKEY_LUKS_SLOT=2 #Set this in case the value is missing in /etc/ykluks.cfg
 
+  if [ -n "$YUBIKEY_CHALLENGE" ]; then
+    YUBIKEY_CHALLENGE_BACKUP="$YUBIKEY_CHALLENGE"
+  fi
+
 . /etc/ykluks.cfg
+
+if [ -n "$YUBIKEY_CHALLENGE_BACKUP" ]; then
+    YUBIKEY_CHALLENGE="$YUBIKEY_CHALLENGE_BACKUP"
+fi
 
 if [ -z "$WELCOME_TEXT" ]; then
     WELCOME_TEXT="Please insert yubikey and press enter or enter a valid passphrase"

--- a/ykluks.cfg
+++ b/ykluks.cfg
@@ -7,7 +7,7 @@ WELCOME_TEXT="Please insert Yubikey and press enter or enter a valid passphrase"
 
 # Set to "1" if you want both your password and Yubikey response be bundled 
 # together and written to the key slot
-CONCATENATE=0
+CONCATENATE=1
 
 # Set to "1" if you want to hash your password with sha256.
 HASH=1
@@ -27,3 +27,12 @@ SUSPEND=0
 # for an unattended boot so long as the Yubikey is present.
 # Leave this empty (or unset), if you want to do 2FA -- i.e. being asked for the password during boot time.
 # YUBIKEY_CHALLENGE="password"
+
+# Set to "1" if you want to enable the extended challenge-response capability.
+# The default challenge-response will transmit the password over the USB
+# connection to the yubikey. This opens the password up to being sniffed on
+# it's way to yubikey. The response from yubikey is also susceptible to sniffing
+# on its way to the system. The extended mode derives a challenge from the password
+# using a one-way digest function. This removes the risk of sniffing all potential
+# inputs to the LUKS password.
+EXTENDED_CHALLENGE=1

--- a/ykluks.cfg
+++ b/ykluks.cfg
@@ -10,7 +10,7 @@ WELCOME_TEXT="Please insert Yubikey and press enter or enter a valid passphrase"
 CONCATENATE=0
 
 # Set to "1" if you want to hash your password with sha256.
-HASH=0
+HASH=1
 
 # Set which Slot to use (1 or 2), defaults to 2
 YUBIKEY_LUKS_SLOT=2

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -7,7 +7,15 @@ YUBIKEY_LUKS_SLOT=2 #Set this in case the value is missing in /etc/ykluks.cfg
 
 
 set -e
+if [ -n "$YUBIKEY_CHALLENGE" ]; then
+    YUBIKEY_CHALLENGE_BACKUP="$YUBIKEY_CHALLENGE"
+fi
+
 . /etc/ykluks.cfg
+
+if [ -n "$YUBIKEY_CHALLENGE_BACKUP" ]; then
+    YUBIKEY_CHALLENGE="$YUBIKEY_CHALLENGE_BACKUP"
+fi
 
 if [ "$(id -u)" -ne 0 ]; then
     echo "You must be root." 1>&2

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -73,15 +73,19 @@ while true ; do
     read -r _ <&1
 done
 
-P1=$(/lib/cryptsetup/askpass "Please enter the yubikey challenge password. This is the password that will only work while your yubikey is installed in your computer:")
-if [ "$DBG" = "1" ]; then echo "Password: $P1"; fi
+if [ -z "$YUBIKEY_CHALLENGE" ]; then
+    P1=$(/lib/cryptsetup/askpass "Please enter the yubikey challenge password. This is the password that will only work while your yubikey is installed in your computer:")
+    if [ "$DBG" = "1" ]; then echo "Password: $P1"; fi
 
-P2=$(/lib/cryptsetup/askpass "Please enter the yubikey challenge password again:")
-if [ "$DBG" = "1" ]; then echo "Password: $P2"; fi
+    P2=$(/lib/cryptsetup/askpass "Please enter the yubikey challenge password again:")
+    if [ "$DBG" = "1" ]; then echo "Password: $P2"; fi
 
-if [ "$P1" != "$P2" ]; then
-    echo "Passwords do not match"
-    exit 1
+    if [ "$P1" != "$P2" ]; then
+        echo "Passwords do not match"
+        exit 1
+    fi
+else
+    P1=$YUBIKEY_CHALLENGE
 fi
 
 if [ "$HASH" = "1" ]; then

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -92,8 +92,12 @@ if [ "$HASH" = "1" ]; then
     P1=$(printf %s "$P1" | sha256sum | awk '{print $1}')
     if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
 fi
-
-R="$(printf %s "$P1" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+if [ -z "$EXTENDED_CHALLENGE" ]; then
+    R="$(printf %s "$P1" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+else
+    yubikey_challenge=$(printf %s "yubikey-$P1" | sha256sum | awk '{print $1}')
+    R="$(printf %s "$yubikey_challenge" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+fi
 if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
 if [ -z "$R" ]; then

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -43,7 +43,11 @@ while true ; do
     read -r _ <&1
 done
 
-P1=$(/lib/cryptsetup/askpass "Enter password created with yubikey-luks-enroll:")
+if [ -z "$YUBIKEY_CHALLENGE" ]; then
+    P1=$(/lib/cryptsetup/askpass "Enter password created with yubikey-luks-enroll:")
+else
+    P1=$YUBIKEY_CHALLENGE
+fi
 if [ "$DBG" = "1" ]; then echo "Password: $P1"; fi
 
 if [ "$HASH" = "1" ]; then

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -55,7 +55,13 @@ if [ "$HASH" = "1" ]; then
     if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
 fi
 
-R="$(printf %s "$P1" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+echo "Sending challenge to yubikey. If necessary, please touch yubikey to authorize use of embedded secret ..."
+if [ -z "$EXTENDED_CHALLENGE" ]; then
+    R="$(printf %s "$P1" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+else
+    yubikey_challenge=$(printf %s "yubikey-$P1" | sha256sum | awk '{print $1}')
+    R="$(printf %s "$yubikey_challenge" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+fi
 if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
 if [ -z "$R" ]; then

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -5,7 +5,15 @@ DBG=0
 YUBIKEY_LUKS_SLOT=2 #Set this in case the value is missing in /etc/ykluks.cfg
 
 set -e
+if [ -n "$YUBIKEY_CHALLENGE" ]; then
+    YUBIKEY_CHALLENGE_BACKUP="$YUBIKEY_CHALLENGE"
+fi
+
 . /etc/ykluks.cfg
+
+if [ -n "$YUBIKEY_CHALLENGE_BACKUP" ]; then
+    YUBIKEY_CHALLENGE="$YUBIKEY_CHALLENGE_BACKUP"
+fi
 
 while getopts ":d:n:hv" opt; do
     case $opt in


### PR DESCRIPTION
The upstream version of the repository supported the ability to send a challenge, or hash thereof, to the yubikey. The yubikey would make use of the built-in hmac-sha1 capability to generate a response. This result for the yubikey is then utilized for unlocking the luks partition. As originally written leaves a risk in the design that a capture of all the serial traffic on the USB port would provide knowledge of the raw password for the luks partition. These updates addresses this risk by ensuring that some aspect of the luks key is not released out of the confines of the compute environment. In essence, the challenge is passed through a one-way digest so that a derived challenge for the yubikey is utilized. Sniffing the usb traffic only provides half of the key and thus a replay attack is still necessary.